### PR TITLE
Extend CaseSplit to provide a more convenient API to HIE

### DIFF
--- a/GhcMod/Exe/CaseSplit.hs
+++ b/GhcMod/Exe/CaseSplit.hs
@@ -2,6 +2,8 @@
 
 module GhcMod.Exe.CaseSplit (
     splits
+  , splits'
+  , SplitResult(..)
   ) where
 
 import Data.List (find, intercalate)
@@ -42,8 +44,15 @@ data SplitToTextInfo = SplitToTextInfo { sVarName     :: String
                                        , sVarSpan     :: SrcSpan
                                        , sTycons      :: [String]
                                        }
+data SplitResult = SplitResult { sStartLine :: Int
+                               , sStartCol  :: Int
+                               , sEndLine   :: Int
+                               , sEndCol    :: Int
+                               , sNewText   :: T.Text }
 
 -- | Splitting a variable in a equation.
+-- Unlike splits', this performs parsing an type checking on every invocation.
+-- This is meant for consumption by tools that call ghc-mod as a binary.
 splits :: IOish m
        => FilePath     -- ^ A target file.
        -> Int          -- ^ Line number.
@@ -56,7 +65,9 @@ splits file lineNo colNo =
       style <- getStyle
       dflag <- G.getSessionDynFlags
       modSum <- fileModSummaryWithMapping (cradleCurrentDir crdl </> file)
-      whenFound' oopts (getSrcSpanTypeForSplit modSum lineNo colNo) $ \x -> do
+      p <- G.parseModule modSum
+      tcm <- G.typecheckModule p
+      whenFound' oopts (getSrcSpanTypeForSplit tcm lineNo colNo) $ \x -> do
           let (varName, bndLoc, (varLoc,varT))
                 | (SplitInfo vn bl vlvt _matches) <- x
                 = (vn, bl, vlvt)
@@ -73,21 +84,51 @@ splits file lineNo colNo =
            text "" $$ nest 4 (showToDoc ex)
      emptyResult =<< outputOpts
 
+-- | Split an identifier in a function definition.
+-- Meant for library-usage.
+splits' :: IOish m => FilePath -> TypecheckedModule -> Int -> Int -> GhcModT m (Maybe SplitResult)
+splits' file tcm lineNo colNo =
+  ghandle handler $ runGmlT' [Right modName] deferErrors $ do
+    style <- getStyle
+    dflag <- G.getSessionDynFlags
+    Just x <- getSrcSpanTypeForFnSplit tcm lineNo colNo
+    let (varName, bndLoc, (varLoc,varT))
+          | (SplitInfo vn bl vlvt _matches) <- x
+          = (vn, bl, vlvt)
+          | (TySplitInfo vn bl vlvt) <- x
+          = (vn, bl, vlvt)
+        varName' = showName dflag style varName  -- Convert name to string
+        (G.RealSrcLoc startLoc) = G.srcSpanStart bndLoc
+        (G.RealSrcLoc endLoc)   = G.srcSpanEnd bndLoc
+        startLine = G.srcLocLine startLoc
+        startCol  = G.srcLocLine startLoc
+        endLine   = G.srcLocCol endLoc
+        endCol    = G.srcLocCol endLoc
+    t <- withMappedFile file $ \file' ->
+          genCaseSplitTextFile file' (SplitToTextInfo varName' bndLoc varLoc $
+                                      getTyCons dflag style varName varT)
+    return $ Just $ SplitResult startLine startCol endLine endCol $ T.pack t
+  where
+    modName = G.ms_mod_name $ pm_mod_summary $ tm_parsed_module tcm
+
+    handler (SomeException ex) = do
+      gmLog GmException "splits'" $
+            text "" $$ nest 4 (showToDoc ex)
+      return Nothing
+
 ----------------------------------------------------------------
 -- a. Code for getting the information of the variable
 
-getSrcSpanTypeForSplit :: GhcMonad m => G.ModSummary -> Int -> Int -> m (Maybe SplitInfo)
-getSrcSpanTypeForSplit modSum lineNo colNo = do
-  fn <- getSrcSpanTypeForFnSplit modSum lineNo colNo
+getSrcSpanTypeForSplit :: GhcMonad m => TypecheckedModule -> Int -> Int -> m (Maybe SplitInfo)
+getSrcSpanTypeForSplit tcm lineNo colNo = do
+  fn <- getSrcSpanTypeForFnSplit tcm lineNo colNo
   if isJust fn
      then return fn
-     else getSrcSpanTypeForTypeSplit modSum lineNo colNo
+     else getSrcSpanTypeForTypeSplit tcm lineNo colNo
 
 -- Information for a function case split
-getSrcSpanTypeForFnSplit :: GhcMonad m => G.ModSummary -> Int -> Int -> m (Maybe SplitInfo)
-getSrcSpanTypeForFnSplit modSum lineNo colNo = do
-    p@ParsedModule{pm_parsed_source = _pms} <- G.parseModule modSum
-    tcm@TypecheckedModule{tm_typechecked_source = tcs} <- G.typecheckModule p
+getSrcSpanTypeForFnSplit :: GhcMonad m => TypecheckedModule -> Int -> Int -> m (Maybe SplitInfo)
+getSrcSpanTypeForFnSplit tcm@TypecheckedModule{tm_typechecked_source = tcs} lineNo colNo = do
     let varPat = find isPatternVar $ listifySpans tcs (lineNo, colNo) :: Maybe (LPat Gap.GhcTc)
         match  = last $ listifySpans tcs (lineNo, colNo) :: Gap.GLMatchI
     case varPat of
@@ -119,8 +160,8 @@ getPatternVarName (L _ (G.VarPat vName)) = G.getName vName
 getPatternVarName _                      = error "This should never happened"
 
 -- TODO: Information for a type family case split
-getSrcSpanTypeForTypeSplit :: GhcMonad m => G.ModSummary -> Int -> Int -> m (Maybe SplitInfo)
-getSrcSpanTypeForTypeSplit _modSum _lineNo _colNo = return Nothing
+getSrcSpanTypeForTypeSplit :: GhcMonad m => TypecheckedModule -> Int -> Int -> m (Maybe SplitInfo)
+getSrcSpanTypeForTypeSplit _tcm _lineNo _colNo = return Nothing
 
 ----------------------------------------------------------------
 -- b. Code for getting the possible constructors
@@ -130,6 +171,7 @@ getTyCons dflag style name ty | Just (tyCon, _) <- Ty.splitTyConApp_maybe ty =
   let name' = showName dflag style name  -- Convert name to string
   in getTyCon dflag style name' tyCon
 getTyCons dflag style name _ = [showName dflag style name]
+
 
 -- Write cases for one type
 getTyCon :: DynFlags -> PprStyle -> String -> Ty.TyCon -> [String]


### PR DESCRIPTION
In response to haskell/haskell-ide-engine#530, this PR adds a `splits'` function that performs case splitting and returns structured output. This makes it more convenient over the existing `splits` function, which returns a `String`. It also allows the user to perform case splitting without needing to re-parse and type check the entire module.

Aside from the functionality, there are also some cosmetic changes to the code which I think make it nice to read. If you want to see just the minimal change without refactorings, see the first commit.

Let me know what you think and if anything needs to change/improve!