### PR TITLE
Fix case splitting for GHC 8.2.2 and 8.4.2

### DIFF
--- a/core/GhcMod/Gap.hs
+++ b/core/GhcMod/Gap.hs
@@ -618,7 +618,9 @@ type GhcRn = Name
 type GhcTc = Id
 #endif
 
-#if __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 840
+type GLMatchI = LMatch GhcTc (LHsExpr GhcTc)
+#elif __GLASGOW_HASKELL__ >= 708
 type GLMatch = LMatch GhcPs (LHsExpr GhcPs)
 type GLMatchI = LMatch Id (LHsExpr Id)
 #else

--- a/core/GhcMod/Gap.hs
+++ b/core/GhcMod/Gap.hs
@@ -618,7 +618,7 @@ type GhcRn = Name
 type GhcTc = Id
 #endif
 
-#if __GLASGOW_HASKELL__ >= 840
+#if __GLASGOW_HASKELL__ >= 804
 type GLMatchI = LMatch GhcTc (LHsExpr GhcTc)
 #elif __GLASGOW_HASKELL__ >= 708
 type GLMatch = LMatch GhcPs (LHsExpr GhcPs)


### PR DESCRIPTION
This PR currently contains a fix to get case splitting to work with GHC 8.2.2.

I'm still trying to figure out what exactly goes wrong for 8.4.2. I found that the list of `GLMatchI` returned from `listifySpans` is empty ([here](https://github.com/txsmith/ghc-mod/blob/3026b8b0ecfce8c2c020cc1de95fe81542d2e56f/GhcMod/Exe/CaseSplit.hs#L141)). Therefore ghc-mod crashes with an empty list exception.

~~I've checked the contents of the `TypecheckedSource` to see if it contains the binding that I'm invoking `splits'` on, and it does. So I'm not quite sure why `listifySpans` returns no matched bindings. Perhaps  something changed in the AST for 8.4.2 so it cannot find an exact match anymore?~~

The problem was indeed a change in the AST. As of 8.4.1, `TypecheckedSource` is no longer a synonym for `LHsBinds Id`, but instead changed to `LHsBinds GhcTc`.

Suggestions and comments are welcome!

