### PR TITLE
Allow parsed module to be saved in getTypecheckedModuleGhc

### DIFF
--- a/core/GhcModCore.hs
+++ b/core/GhcModCore.hs
@@ -41,8 +41,8 @@ module GhcModCore (
   , loadMappedFileSource
   , unloadMappedFile
   -- * HIE integration utilities
-  , getTypecheckedModuleGhc
-  , getTypecheckedModuleGhc'
+  , getModulesGhc
+  , getModulesGhc'
   ) where
 
 import GhcMod.Cradle


### PR DESCRIPTION
This is used in https://github.com/bubba/haskell-ide-engine/tree/cached-parsed-modules