### PR TITLE
Fix haskell-ide-engine#667 by reading any source files as UTF8

### DIFF
--- a/core/GhcMod/HomeModuleGraph.hs
+++ b/core/GhcMod/HomeModuleGraph.hs
@@ -62,7 +62,7 @@ import GhcMod.Logging
 import GhcMod.Logger
 import GhcMod.Monad.Types
 import GhcMod.Types
-import GhcMod.Utils (withMappedFile)
+import GhcMod.Utils (withMappedFile, readUtf8File)
 import GhcMod.Gap (parseModuleHeader)
 
 -- | Turn module graph into a graphviz dot file
@@ -212,7 +212,7 @@ updateHomeModuleGraph' env smp0 = do
    step :: ModulePath -> m (Maybe (Set ModulePath))
    step mp = runMaybeT $ do
        (dflags, ppsrc_fn) <- MaybeT preprocess'
-       src <- liftIO $ readFile ppsrc_fn
+       src <- liftIO $ readUtf8File ppsrc_fn
        imports mp src dflags
     where
       preprocess' :: m (Maybe (DynFlags, FilePath))
@@ -261,7 +261,7 @@ fileModuleName env fn = do
       Left errs -> do
         return $ Left errs
       Right (_warns, (dflags, procdFile)) -> leftM (errBagToStrList env) =<< handler (do
-        src <- readFile procdFile
+        src <- readUtf8File procdFile
         case parseModuleHeader src dflags procdFile of
           Left errs -> return $ Left errs
           Right (_, lmdl) -> do

--- a/core/GhcMod/Utils.hs
+++ b/core/GhcMod/Utils.hs
@@ -21,6 +21,7 @@ module GhcMod.Utils (
     module GhcMod.Utils
   , module Utils
   , readProcess
+  , readUtf8File
   ) where
 
 import Control.Applicative
@@ -36,6 +37,7 @@ import GhcMod.Monad.Types
 import System.Directory
 import System.Environment
 import System.FilePath
+import System.IO (openFile, hSetEncoding, utf8, hGetContents, IOMode (ReadMode))
 import System.IO.Temp (createTempDirectory)
 import System.Process (readProcess)
 import Text.Printf
@@ -163,3 +165,10 @@ makeAbsolute' = (normalise <$>) . absolutize
   where absolutize path -- avoid the call to `getCurrentDirectory` if we can
           | isRelative path = (</> path) <$> getCurrentDirectory
           | otherwise       = return path
+
+
+readUtf8File :: FilePath -> IO String
+readUtf8File path = do
+  hd <- openFile path ReadMode
+  hSetEncoding hd utf8
+  hGetContents hd


### PR DESCRIPTION
https://github.com/haskell/haskell-ide-engine/issues/667 `hGetContents: invalid argument (invalid byte sequence)` on Japanese Windows

I'm not sure how to add test for this bug.
I'm glad if you have some advice.