### PR TITLE
Add cradleGhcVersion

### DIFF
--- a/core/GhcMod/Types.hs
+++ b/core/GhcMod/Types.hs
@@ -28,6 +28,7 @@ import Data.Maybe
 import Data.Typeable (Typeable)
 import Data.IORef
 import Data.Label.Derive
+import Data.Version
 import Distribution.Helper hiding (Programs(..))
 import qualified Distribution.Helper as CabalHelper
 import Exception (ExceptionMonad)
@@ -165,6 +166,8 @@ data Cradle = Cradle {
   , cradleCabalFile  :: Maybe FilePath
   -- | The build info directory.
   , cradleDistDir    :: FilePath
+  -- | GHC version
+  , cradleGhcVersion :: Version
   } deriving (Eq, Show, Ord)
 
 data LoadGhcEnvironment = LoadGhcEnvironment


### PR DESCRIPTION
Differs from the `compilerVersion` cabal-helper query in that it presumes the compiler is GHC, and it runs processes to determine the version.

This changes the `Cradle` type so a major version bump might be needed. Part of https://github.com/haskell/haskell-ide-engine/issues/1023