### PR TITLE
Initialise compiler plugins before loading a target

### DIFF
--- a/core/GhcMod/Target.hs
+++ b/core/GhcMod/Target.hs
@@ -47,6 +47,7 @@ import GHC.LanguageExtensions
 import DynFlags
 import HscTypes
 import Pretty
+import DynamicLoading
 
 import GhcMod.Caching
 import GhcMod.Cradle
@@ -557,6 +558,11 @@ loadTargets opts targetStrs mUpdateHooks = do
     setTargets targets
 
     when filterModSums $ updateModuleGraph setDynFlagsRecompile targetFileNames
+    dynFlags' <- getSessionDynFlags
+    dynFlags <- liftIO $ withLightHscEnv loadGhcEnv opts $ \env ->
+          DynamicLoading.initializePlugins env dynFlags'
+    _ <- setSessionDynFlags dynFlags
+    gmLog GmInfo "loadTargets" $ text "Initialised plugins"
 
     mg <- depanal [] False
 


### PR DESCRIPTION
This initialises plugins before loading the target.
closes [#1264](https://github.com/haskell/haskell-ide-engine/issues/1264)

What works: 
Example project at  [polysemy-hie-experiment](https://github.com/fendor/polysemy-hie-experiment)
Current behaviour: Compiler error, ambiguous types.
Expected behavior: compiles.

This works now if the flag `-fplugin=Polysemy.Plugin` is specified in the *.cabal file.
However, the option `{-# OPTIONS_GHC -fplugin=Polysemy.Plugin #-}` in the source file does not suffice currently. 

See #18 for initial discussion