### PR TITLE
 Load plugins in the frontend and honour pragmas and cabal 

### DIFF
--- a/core/GhcMod/Target.hs
+++ b/core/GhcMod/Target.hs
@@ -47,7 +47,6 @@ import GHC.LanguageExtensions
 import DynFlags
 import HscTypes
 import Pretty
-import DynamicLoading
 
 import GhcMod.Caching
 import GhcMod.Cradle
@@ -558,11 +557,6 @@ loadTargets opts targetStrs mUpdateHooks = do
     setTargets targets
 
     when filterModSums $ updateModuleGraph setDynFlagsRecompile targetFileNames
-    dynFlags' <- getSessionDynFlags
-    dynFlags <- liftIO $ withLightHscEnv loadGhcEnv opts $ \env ->
-          DynamicLoading.initializePlugins env dynFlags'
-    _ <- setSessionDynFlags dynFlags
-    gmLog GmInfo "loadTargets" $ text "Initialised plugins"
 
     mg <- depanal [] False
 


### PR DESCRIPTION
This is a follow up to #19 which reverts changes of #19.
@mpickering fixed the problem of #19, that plugin pragmas in source files are not being honoured.
Now ghc-mod correctly detects the plugin param in *.cabal and source pragma.

This reverts the previous changes since they are not necessary anymore.
Problem: In the logs of ghc-mod, you still see the type errors, but they are not reported to hie. May lead to confusion for people that have the logs constantly open.
 